### PR TITLE
Fix pycountry's field names.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'clldmpg~=3.1',
         'python-docx',
         'sqlalchemy',
-        'pycountry',
+        'pycountry>=16.11.8',
         'waitress',
     ],
     extras_require={

--- a/tsammalex/scripts/util.py
+++ b/tsammalex/scripts/util.py
@@ -68,7 +68,8 @@ def get_center(arr):
 
 def load_countries(data):
     for country in countries:
-        data.add(Country, country.alpha2, id=country.alpha2, name=country.name)
+        data.add(Country, country.alpha_2, id=country.alpha_2,
+                 name=country.name)
 
 
 def load_ecoregions(data_file, data):


### PR DESCRIPTION
Needed for having a working `initializedb.py` and not wanting to use ancient `pycountry` versions.